### PR TITLE
Migrate to Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ ENV MYSQL_DATABASE=browsebox\
 # Run SQL scripts
 ADD ./browsebox-backend/database/browsebox.sql /docker-entrypoint-initdb.d/
 ADD ./browsebox-backend/database/review_score_trigger.sql /docker-entrypoint-initdb.d/
+ADD ./browsebox-backend/database/populate.sql /docker-entrypoint-initdb.d/
 
 EXPOSE 3306

--- a/README.md
+++ b/README.md
@@ -12,14 +12,11 @@ Please make sure you have the following prerequisites:
 
 - An IDE such as [Visual Studio Code](https://code.visualstudio.com/download) or [WebStorm](https://www.jetbrains.com/webstorm/)
 - Node.js 18.3.0
-- Docker
+- Docker and Docker Compose
 
-## Running the database with Docker
+## Running the back end with Docker
 
 - Install [Docker](https://www.docker.com/community-edition) and [git](https://git-scm.com).
-- If you're using Windows, make sure it's running at least build 2004 and install Ubuntu (or another Linux distro of choice) from the Windows Store. Additionally:
-  - Make sure it's running WSL2 (convert it if it's still using WSL1).
-  - Open Docker settings, go to Resources → WSL Integration → Enable integration with additional distros (enable for the installed distro).
 - Open any terminal of your choice.
 - Clone your fork of this repository.
 
@@ -32,10 +29,14 @@ Navigate to the root of the repository and run this command to build an image of
 docker build -t browsebox-mysql .
 ```
 
-Create a new container and run the database.
+Ensure your image is up-to-date and rebuild periodically whenever neccessary. In order to update the image, you must remove the image with `docker image rm [image-name]` and rerun the build command.
+
+### Running with `docker-compose`
+
+Once you've finished building the image, run this command to start the back end.
 
 ```bash
-docker run --name mysql-container -dp 3306:3306 browsebox-mysql
+docker-compose up
 ```
 
 ## Installing dependencies
@@ -48,4 +49,4 @@ npm install
 
 ## Licence
 
-BrowseBox code and framework are licensed under the [MIT licence](https://opensource.org/licenses/MIT). Please see [the licence file](LICENCE) for more information. [tl;dr](https://tldrlegal.com/license/mit-license) you can do whatever you want as long as you include the original copyright and license notice in any copy of the software/source.
+BrowseBox code is licensed under the [MIT licence](https://opensource.org/licenses/MIT). Please see [the licence file](LICENCE) for more information. [tl;dr](https://tldrlegal.com/license/mit-license) you can do whatever you want as long as you include the original copyright and license notice in any copy of the software/source.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# browsebox-web 
+# browsebox-web
 
 [![Build status](https://github.com/browsebox/browsebox-web/actions/workflows/ci.yml/badge.svg?branch=master&event=push)](https://github.com/browsebox/browsebox-web/actions/workflows/ci.yml)
 [![GitHub release](https://img.shields.io/github/release/browsebox/browsebox-web.svg)](https://github.com/browsebox/browsebox-web/releases/latest)
@@ -29,13 +29,13 @@ Managing docker images and containers can be done from Docker Desktop, but we wi
 Navigate to the root of the repository and run this command to build an image of the database.
 
 ```bash
-docker build -t mysql-image .
+docker build -t browsebox-mysql .
 ```
 
 Create a new container and run the database.
 
 ```bash
-docker run --name mysql-container -dp 3306:3306 mysql-image
+docker run --name mysql-container -dp 3306:3306 browsebox-mysql
 ```
 
 ## Installing dependencies

--- a/browsebox-backend/database/DATABASE.md
+++ b/browsebox-backend/database/DATABASE.md
@@ -1,3 +1,4 @@
 # Run SQL files in order:
 1. browsebox.sql
 2. review_score_trigger.sql
+3. populate.sql

--- a/browsebox-backend/database/populate.sql
+++ b/browsebox-backend/database/populate.sql
@@ -1,0 +1,24 @@
+insert into users(user_id, user_name, user_email, user_rating, user_password) values (1, 'admin', 'admin@browsebox.com', 5.00, 'admin_password');
+insert into users(user_id, user_name, user_email, user_rating, user_password) values (2, 'meow', 'cats@gmail.com', 3.73, 'meow');
+insert into users(user_id, user_name, user_email, user_rating, user_password) values (3, 'tom21', 'tom@outlook.com', 2.98, 'password');
+
+insert into schools(school_id, school_name, school_link) values (1, 'Southern Alberta Institute of Technology', 'https://www.sait.ca');
+insert into schools(school_id, school_name, school_link) values (2, 'University of Calgary', 'https://www.ucalgary.ca');
+
+insert into reviews(review_id, reviewer, user_id, review_description, review_value) values (20584, 2, 1, 'This was great!', 5.00);
+
+insert into sales(sale_id, owner, sale_description, sale_price) values (1, 2, 'random cat toy', 258.34);
+insert into sales(sale_id, owner, sale_description, sale_price) values (2, 3, 'Graphing Calculator', 2.34);
+insert into sales(sale_id, owner, sale_description, sale_price) values (3, 3, 'Pencil', 112.34);
+
+insert into categories(cat_id, cat_name) values (1, 'Calculator');
+insert into categories(cat_id, cat_name) values (2, 'Textbook');
+insert into categories(cat_id, cat_name) values (3, 'Stationary');
+insert into categories(cat_id, cat_name) values (4, 'Computer');
+insert into categories(cat_id, cat_name) values (5, 'Misc');
+
+insert into favorites(user_id, sale_id) values (1, 2);
+
+insert into tag_sales(cat_id, sale_id) values (1, 2);
+insert into tag_sales(cat_id, sale_id) values (3, 3);
+insert into tag_sales(cat_id, sale_id) values (5, 1);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+    database:
+        image: browsebox-mysql
+        container_name: browsebox-database
+        environment:
+            MYSQL_ROOT_PASSWORD: password
+            MYSQL_DATABASE: browsebox
+            MYSQL_USER: user
+            MYSQL_PASSWORD: password
+        volumes:
+            - .:/database/var/lib/mysql
+        ports:
+            - 3306:3306
+        restart: always


### PR DESCRIPTION
Using the `docker-compose` command should make docker management much more easier. You no longer have to manually specify which container to run or even use the Docker Desktop GUI (maybe). 

This also has the added benefits of scaling our backend services better, as eventually we would want to run the database, server, and other services on docker to emulate a production environment locally as much as possible.

There are really just two commands to remember to start/stop the backend services:
`docker-compose up` and `docker-compose down`.

I’ve added instructions in the README on how to update the database image whenever it’s outdated. I’ll probably ping the teams chat whenever there’s an update to the database `.sql` files.

## Known issues

- Existing MySQL installations might conflict with ports (3306)
- Docker does not start on some computers
As a workaround, using your existing MySQL installation and running the server manually should be fine.